### PR TITLE
Use overflow operator to prevent crash when number of characters input > 125 char

### DIFF
--- a/Fuse/Classes/Fuse.swift
+++ b/Fuse/Classes/Fuse.swift
@@ -225,7 +225,7 @@ public class Fuse {
             
             // Initialize the bit array
             var bitArr = [Int](repeating: 0, count: finish + 2)
-            bitArr[finish + 1] = (1 << i) - 1
+            bitArr[finish + 1] = (1 << i) &- 1
             
             if start > finish {
                 continue


### PR DESCRIPTION
This story closes [CH17482](https://app.shortcut.com/slumber-group/story/17482/app-crashes-when-more-than-125-characters-are-typed-in-search-bar).

## Context
Arithmetic overflow when number of chars in input > 125 because the algorithm reaches Int.max then attempt to subtract 1.

## Fix 
Using overflow operator to substract.